### PR TITLE
h5py input files

### DIFF
--- a/chempath.py
+++ b/chempath.py
@@ -36,6 +36,7 @@ class Chempath():
         ):
 
         with h5py.File(h5py_path, 'r') as datafile:
+            self.h5py_path = h5py_path
             self.f_min = f_min
             # ignore_warnings
             self.warnings = warnings
@@ -114,14 +115,9 @@ class Chempath():
     def reinit(self):
         '''Re-initializes the chempath object with the input information'''
         self.__init__(
-        reactions_path = self.reactions_path,
-        rates_path = self.rates_path,
-        species_path = self.species_path,
-        conc_path = self.conc_path,
-        time_path = self.time_path,
+        h5py_path=self.h5py_path,
         f_min = self.f_min,
         warnings = self.warnings,
-        dtype = self.dtype,
         transport_species = self.transport_species,
         ignored_sb = self.ignored_sb,
         n_processes = self.n_processes

--- a/chempath.py
+++ b/chempath.py
@@ -3,12 +3,11 @@ import numpy as np
 import pandas as pd
 from itertools import product
 from scipy.optimize import lsq_linear, linprog
-from copy import deepcopy
 from scipy import sparse
 from string import Template
 import errno
 import os
-import sys
+import h5py
 import signal
 import warnings 
 from joblib import Parallel, delayed
@@ -18,13 +17,8 @@ class Chempath():
     '''
     Pathway analysis program class.
     Arguments:
-        reactions_path(str): path of input reactions equations
-        rates_path (str): path of input reactions rates
-        species_path (str): path of input species names
-        conc_path (str): path of input species concentrations
-        time_path (str): path of input model time
+        h5py_path (str): path of h5py data file containing input data
         f_min (float): minimum rate of pathways. Defaults to 0.0
-        dtype (type): number type of numerical fields
         ignored_sb (list): List of species ignored as branching-points. These
             species will not be considered as branching-point species.
         n_processes (int): Number of processes to use to construct pathways. If
@@ -32,103 +26,89 @@ class Chempath():
             multiprocessing
     '''
     def __init__(self, 
-        reactions_path,
-        rates_path,
-        species_path,
-        conc_path,
-        time_path,
+        h5py_path,
         f_min=0, 
         warnings=True, 
-        dtype=np.float128,
         transport_species = False,
         ignored_sb = [],
         n_processes = 1,
         delete_error_reactions = False
         ):
 
-        # path of input reactions equations
-        self.reactions_path = reactions_path
-        # path of input reactions rates
-        self.rates_path = rates_path
-        # path of input species names
-        self.species_path = species_path
-        # path of input species concentrations
-        self.conc_path = conc_path
-        # path of input model time
-        self.time_path = time_path
-        # path of input model time
-        self.f_min = f_min
-        # ignore_warnings
-        self.warnings = warnings
-        # number type of numerical fields
-        self.dtype = dtype
-        # time 
-        self.time = read_time_file(time_path, dtype=dtype)
-        self.dt = self.time[1] - self.time[0]
-        # model time
-        self.mean_time = np.mean(self.time)
-        # species list
-        self.species_list = read_species_file(species_path)
-        # concentrations
-        self.conc = read_conc_file(conc_path, len(self.species_list), dtype=dtype)
-        # concentratio change
-        self.dconc = self.conc[1] - self.conc[0]
-        # mean concentration
-        self.mean_conc = np.trapezoid(self.conc,self.time, axis=0) / self.dt
-        # mean rate of concentration change
-        self.mean_dconc = np.array(self.dconc) / self.dt 
-        # reactions and rates
-        self.reaction_equations = read_reactions_file(reactions_path)
-        self.rj = read_rates(rates_path, dtype=dtype)
-        self.delete_zero_reactions()
-        self.invert_negative_rates()
-        # part of rate of reaction j associated with deleted pathways
-        self.rj_del = np.zeros(len(self.reaction_equations), dtype=np.float128)
-        # part of rate of reaction j associated with error pathways
-        self.rj_err = np.zeros(len(self.reaction_equations), dtype=np.float128)
-        # molecules of species i produces or destroyed by reaction j
-        self.sij = get_sij(self.species_list, self.reaction_equations)
-        # multiplicity of reaction j in pathway k
-        self.xjk = np.diag(np.ones(len(self.reaction_equations), dtype=int))
-        self.xjk = sparse.csc_matrix(self.xjk)
-        # list of pathways pathways by unique id
-        self.pathway_ids = xjk_to_id_list(self.xjk)
-        # molecules of species i produces or destroyed by pathway k
-        self.mik = sparse_dot(self.sij, self.xjk)
-        # rates of pathways
-        self.fk = self.rj
-        # rate of production of species i by deleted pathways
-        self.pi_del = np.zeros(len(self.species_list), dtype=dtype)
-        # rate of production of species i by error pathways
-        self.pi_err = np.zeros(len(self.species_list), dtype=dtype)
-        # rate of destruction of species i by deleted pathways
-        self.di_del = np.zeros(len(self.species_list), dtype=dtype)
-        # rate of destruction of species i by error pathways
-        self.di_err = np.zeros(len(self.species_list), dtype=dtype)
-        # total rate of production of species i by all pathways
-        self.pi = self.pi_del + np.dot(np.multiply(self.mik, self.mik>0), self.fk)
-        # total rate of destruction of species i by all pathways
-        self.di = self.di_del + np.dot(np.abs(np.multiply(self.mik, self.mik<0)), self.fk)
-        # list of used banching species
-        self.sb_list = []
-        self.sb_order = {}
-        self.ignored_sb = ignored_sb
-        # number of processes to use to construct pathways
-        self.n_processes = n_processes
-        # full list of species including transport species
-        self.transport_species = transport_species
-        # temporary variables to store deleted pathway rates
-        self.rj_del_temp = np.zeros(len(self.reaction_equations), dtype=dtype)
-        self.pi_del_temp = np.zeros(len(self.species_list), dtype=dtype)
-        self.di_del_temp = np.zeros(len(self.species_list), dtype=dtype)
-        if transport_species:
-            transport_species = [f'{x}_transport' for x in self.species_list]
-            self.full_species_list = self.species_list + transport_species
-            self.full_sij = get_sij(self.full_species_list, self.reaction_equations)
+        with h5py.File(h5py_path, 'r') as datafile:
+            self.f_min = f_min
+            # ignore_warnings
+            self.warnings = warnings
+            # time 
+            self.time = datafile['model_time'][:]
+            self.dt = self.time[1] - self.time[0]
+            # model time
+            self.mean_time = np.mean(self.time)
+            # species list
+            species_list = datafile['species_names'][:]
+            self.species_list = [x.decode("utf-8").strip() for x in species_list]
+            # concentrations
+            self.conc = datafile['num_densities'][:]
+            # concentratio change
+            self.dconc = self.conc[1] - self.conc[0]
+            # mean concentration
+            self.mean_conc = np.trapezoid(self.conc,self.time, axis=0) / self.dt
+            # mean rate of concentration change
+            self.mean_dconc = np.array(self.dconc) / self.dt 
+            # reactions and rates
+            reaction_equations = datafile['reaction_equations'][:]
+            self.reaction_equations = [x.decode("utf-8").replace(' ', '') 
+                for x in reaction_equations]
+            self.rj = datafile['rates'][:]
+            self.delete_zero_reactions()
+            self.invert_negative_rates()
+            # part of rate of reaction j associated with deleted pathways
+            self.rj_del = np.zeros(len(self.reaction_equations), dtype=np.longdouble)
+            # part of rate of reaction j associated with error pathways
+            self.rj_err = np.zeros(len(self.reaction_equations), dtype=np.longdouble)
+            # molecules of species i produces or destroyed by reaction j
+            self.sij = get_sij(self.species_list, self.reaction_equations)
+            # multiplicity of reaction j in pathway k
+            self.xjk = np.diag(np.ones(len(self.reaction_equations), dtype=int))
+            self.xjk = sparse.csc_matrix(self.xjk)
+            # list of pathways pathways by unique id
+            self.pathway_ids = xjk_to_id_list(self.xjk)
+            # molecules of species i produces or destroyed by pathway k
+            self.mik = sparse_dot(self.sij, self.xjk)
+            # rates of pathways
+            self.fk = self.rj
+            # rate of production of species i by deleted pathways
+            self.pi_del = np.zeros(len(self.species_list), dtype=np.longdouble)
+            # rate of production of species i by error pathways
+            self.pi_err = np.zeros(len(self.species_list), dtype=np.longdouble)
+            # rate of destruction of species i by deleted pathways
+            self.di_del = np.zeros(len(self.species_list), dtype=np.longdouble)
+            # rate of destruction of species i by error pathways
+            self.di_err = np.zeros(len(self.species_list), dtype=np.longdouble)
+            # total rate of production of species i by all pathways
+            self.pi = self.pi_del + np.dot(np.multiply(self.mik, self.mik>0), self.fk)
+            # total rate of destruction of species i by all pathways
+            self.di = self.di_del + np.dot(np.abs(np.multiply(self.mik, self.mik<0)), self.fk)
+            # list of used banching species
+            self.sb_list = []
+            self.sb_order = {}
+            self.ignored_sb = ignored_sb
+            # number of processes to use to construct pathways
+            self.n_processes = n_processes
+            # full list of species including transport species
+            self.transport_species = transport_species
+            # temporary variables to store deleted pathway rates
+            self.rj_del_temp = np.zeros(len(self.reaction_equations), dtype=np.longdouble)
+            self.pi_del_temp = np.zeros(len(self.species_list), dtype=np.longdouble)
+            self.di_del_temp = np.zeros(len(self.species_list), dtype=np.longdouble)
+            if transport_species:
+                transport_species = [f'{x}_transport' for x in self.species_list]
+                self.full_species_list = self.species_list + transport_species
+                self.full_sij = get_sij(self.full_species_list, self.reaction_equations)
 
-        self.delete_error_reactions = delete_error_reactions
-        if self.delete_error_reactions:
-            self.del_error_reactions()
+            self.delete_error_reactions = delete_error_reactions
+            if self.delete_error_reactions:
+                self.del_error_reactions()
 
 
     def reinit(self):
@@ -147,36 +127,41 @@ class Chempath():
         n_processes = self.n_processes
         )
 
-    def load_pathways_from_files(self, filespath, dtype=np.float128):
+    def load_pathways_from_files(self, filespath, dtype=np.longdouble):
         '''Loads pathway info  saved using the save_pathway_info method
         Arguments:
             filespath(str): path of files to read
             dtype(type): data type of numbers if the files
         '''
-        # part of rate of reaction j deleted pathways
-        self.rj_del = np.fromfile(f'{filespath}/rj_del.dat', dtype=dtype)
         # multiplicity of reaction j in pathway k
         self.xjk = sparse.load_npz(f'{filespath}/sparse_xjk.npz')
         # list of pathways pathways by unique id
         self.pathway_ids = xjk_to_id_list(self.xjk)
         # molecules of species i produces or destroyed by pathway k
         self.mik = sparse_dot(self.sij, self.xjk)
-        # rates of pathways
-        self.fk = np.fromfile(f'{filespath}/fk.dat', dtype=dtype)
-        # rate of production of species i by deleted pathways
-        self.pi_del = np.fromfile(f'{filespath}/pi_del.dat', dtype=dtype)
-        # rate of destruction of species i by deleted pathways
-        self.di_del = np.fromfile(f'{filespath}/di_del.dat', dtype=dtype)
-        # total rate of production of species i by all pathways
-        self.pi = np.fromfile(f'{filespath}/pi.dat', dtype=dtype)
-        # total rate of destruction of species i by all pathways
-        self.di = np.fromfile(f'{filespath}/di.dat', dtype=dtype)
-        # list of used banching species
-        self.sb_list = list(np.loadtxt(f'{filespath}/sb_list.txt', dtype=str,
-            delimiter=','))
-        # list of species not considered as brancing species 
-        self.ignored_sb = list(np.loadtxt(f'{filespath}/ignored_sb.txt',
-            dtype=str, delimiter=','))
+        with h5py.File(f'{filespath}/chempath_info.hdf5', 'r') as datafile:
+            # part of rate of reaction j deleted pathways
+            self.rj_del = datafile['rj_del'][:]
+            # rates of pathways
+            self.fk = datafile['fk'][:]
+            # rate of production of species i by deleted pathways
+            self.pi_del = datafile['pi_del'][:]
+            # rate of destruction of species i by deleted pathways
+            self.di_del = datafile['di_del'][:]
+            # rate of production of species i by error pathways
+            self.pi_err = datafile['pi_err'][:]
+            # rate of destruction of species i by error pathways
+            self.di_err = datafile['di_err'][:]
+            # total rate of production of species i by all pathways
+            self.pi = datafile['pi'][:]
+            # total rate of destruction of species i by all pathways
+            self.di = datafile['di'][:]
+            # list of used banching species
+            self.sb_list = [x.decode("utf-8").strip() 
+                for x in datafile['sb_list'][:]]
+            # list of species not considered as brancing species 
+            self.ignored_sb = [x.decode("utf-8").strip() 
+                for x in datafile['ignored_sb'][:]]
 
         
     def get_sb(self, tau_max=None, min_conc=None):
@@ -227,7 +212,7 @@ class Chempath():
         '''Deletes reactions with a zero rate'''
         delete_idxs = np.where(self.rj == 0)[0]
         self.rj = np.delete(self.rj, delete_idxs)
-        self.reaction_equations = np.delete(self.reaction_equations, delete_idxs)
+        self.reaction_equations = list(np.delete(self.reaction_equations, delete_idxs))
 
     def invert_negative_rates(self):
         '''Inverts reactions with negative rates. We assumed that all rates are
@@ -281,10 +266,10 @@ class Chempath():
         pid_new = []
 
         # variables to store deleted pathway rates
-        rj_del_temp = np.zeros(len(self.reaction_equations), dtype=np.float128)
-        pi_del_temp = np.zeros(len(self.species_list), dtype=np.float128)
-        di_del_temp = np.zeros(len(self.species_list), dtype=np.float128)
-        fk_temp = np.zeros(len(self.fk), dtype=np.float128)
+        rj_del_temp = np.zeros(len(self.reaction_equations), dtype=np.longdouble)
+        pi_del_temp = np.zeros(len(self.species_list), dtype=np.longdouble)
+        di_del_temp = np.zeros(len(self.species_list), dtype=np.longdouble)
+        fk_temp = np.zeros(len(self.fk), dtype=np.longdouble)
 
         # calculate new multiplicities so that sb is recycled
         # and calculate rates of new pathways
@@ -626,7 +611,7 @@ class Chempath():
         fk_elem_list = []
         pid_elem_list = []
         delete_idxs = []
-        fk_temp = np.zeros(len(self.fk), dtype=np.float128)
+        fk_temp = np.zeros(len(self.fk), dtype=np.longdouble)
 
         if new_pathways_flag:
             # for each pathway...
@@ -1018,6 +1003,8 @@ class Chempath():
         contrib_df['dconc'] = self.dconc[sp_idx]
         contrib_df.sort_values('contribution', ascending=False, inplace=True)
         contrib_df = contrib_df.reset_index(drop=True)
+        contrib_df=contrib_df.astype({'contribution':np.float64, 'rate':np.float64,
+            'total_prod':np.float64})
         return contrib_df        
        
     def check_mass_conservation(self, min_concentration=1.0, atol=1e-3,
@@ -1233,70 +1220,28 @@ class Chempath():
             path(str): path where the files will be saved
         '''
         sparse.save_npz(f'{path}/sparse_xjk', self.xjk)
-        self.fk.tofile(f'{path}/fk.dat')
-        np.float128(self.pi).tofile(f'{path}/pi.dat')
-        np.float128(self.di).tofile(f'{path}/di.dat')
-        np.float128(self.pi_del).tofile(f'{path}/pi_del.dat')
-        np.float128(self.di_del).tofile(f'{path}/di_del.dat')
-        np.float128(self.rj_del).tofile(f'{path}/rj_del.dat')
-        np.savetxt(f'{path}/sb_list.txt', self.sb_list, delimiter=",", fmt="%s")
-        np.savetxt(f'{path}/ignored_sb.txt', self.ignored_sb, delimiter=",", fmt="%s")
-
-
-def read_reactions_file(filepath):
-    '''Reads input reactions file
-    Arguments:
-        filepath(str): path of reaction equations file
-    Returns:
-        reactions (list): list of reactions equation strings      
-    '''
-    reactions =  np.loadtxt(filepath, dtype=str, delimiter=',')
-    reactions = [reaction.replace(' ', '') for reaction in reactions]
-    return reactions
-
-def read_rates(filepath, dtype=np.float128):
-    '''Reads input reactions rates file
-    Arguments:
-        filepath(str): path of reactions rates file
-        dtype (type): number type of reaction rates
-    Returns:
-        rates (numpy array): array of reactions rates      
-    '''
-    rates = np.fromfile(filepath, dtype=dtype)
-    return rates
-     
-def read_conc_file(filepath, n_species, dtype=np.float128):
-    '''Reads input species concentrations file
-    Arguments:
-        filepath(str): path of species concentrations file
-        n_species(int): number of species in the reaction system
-        dtype (type): number type of concentrations
-    Returns:
-        conc (numpy array): array of species concentrations   
-    '''
-    conc = np.fromfile(filepath, dtype=dtype).reshape(2, n_species)
-    return  conc
-
-def read_species_file(filepath):
-    '''Reads input species names file
-    Arguments:
-        filepath(str): path of species names file
-    Returns:
-        species (numpy array): array of species names      
-    '''
-    species =  list(np.loadtxt(filepath, dtype=str, delimiter=','))
-    return species
-
-def read_time_file(filepath, dtype=np.float128):
-    '''Reads input model time file
-    Arguments:
-        filepath(str): path of model time file
-        dtype (type): number type of model time
-    Returns:
-        species (numpy array): array of species names      
-    '''
-    time = np.fromfile(filepath, dtype=dtype)
-    return time
+        h5py_filename = f"{path}/chempath_info.hdf5"
+        with h5py.File(h5py_filename, "w") as datafile:
+            datafile.create_dataset("fk", self.fk.shape, dtype='f16', 
+                data=self.fk)
+            datafile.create_dataset("pi", self.pi.shape, dtype='f16', 
+                data=self.pi)
+            datafile.create_dataset("di", self.di.shape, dtype='f16', 
+                data=self.di)
+            datafile.create_dataset("pi_del", self.pi_del.shape, dtype='f16', 
+                data=self.pi_del)
+            datafile.create_dataset("di_del", self.di_del.shape, dtype='f16', 
+                data=self.di_del)
+            datafile.create_dataset("pi_err", self.pi_err.shape, dtype='f16', 
+                data=self.pi_err)
+            datafile.create_dataset("di_err", self.di_err.shape, dtype='f16', 
+                data=self.di_err)
+            datafile.create_dataset("rj_del", self.rj_del.shape, dtype='f16', 
+                data=self.rj_del)
+            datafile.create_dataset("sb_list", [len(self.sb_list)], 
+                    dtype=h5py.string_dtype(), data=self.sb_list)
+            datafile.create_dataset("ignored_sb", [len(self.ignored_sb)], 
+                    dtype=h5py.string_dtype(), data=self.ignored_sb)
 
 def solve_system_eq(a,b):
     ''' Solves system of equations ax=b
@@ -1379,28 +1324,6 @@ def xjk_to_id_list(xjk):
     for i in range(xjk.shape[1]):
         id_list.append(get_pathway_id(xjk[:, i]))
     return np.array(id_list)
-
-# def delete_duplicated_pathways(pathway_ids,fk, xjk):
-#     '''Deletes duplicated pathways'''
-#     u, c = np.unique(pathway_ids, return_counts=True)
-#     duplicates = u[c>1]
-#     if len(duplicates) > 0:
-#         df = pd.DataFrame({'pid': pathway_ids, 'fk': fk,
-#             'idx': np.arange(0, len(fk))})
-#         df.fk = df.fk.astype('float128') 
-#         df1 = df.groupby('pid').sum().reset_index()[['pid', 'fk']]
-#         df2 = df[['pid', 'idx']].drop_duplicates(subset='pid', keep='first')
-#         df = pd.merge(df1, df2, on='pid', how='inner')
-
-#         idxs = df.idx.to_numpy()
-#         pids = df.pid.to_numpy()
-#         fk = df.fk.to_numpy().astype(np.float128)
-        
-#         xjk = xjk[:, idxs]
-#         pathway_ids = pids
-#         fk = fk
-#     return pathway_ids, fk, xjk
-
 
 def format_react_txt(reacts, prods):
     '''Gets a reaction string in a txt format

--- a/chempath_tests.py
+++ b/chempath_tests.py
@@ -2,17 +2,12 @@ import unittest
 import numpy as np
 from chempath import Chempath
 
-def get_chempath(input_folder, ignored_sb=[]):
+def get_chempath(h5py_file, ignored_sb=[]):
     '''Gets a chempath object given an input folder and a list of species
     of interest'''
     chempath = Chempath(
-        reactions_path=f'{input_folder}/reactions.txt',
-        rates_path=f'{input_folder}/rates.dat',
-        species_path=f'{input_folder}/species.txt',
-        conc_path=f'{input_folder}/concentrations.dat',
-        time_path=f'{input_folder}/model_time.dat',
+        h5py_path=h5py_file,
         f_min=0, 
-        dtype=np.float64,
         ignored_sb = ignored_sb
     )
     return chempath
@@ -21,7 +16,7 @@ def get_chempath(input_folder, ignored_sb=[]):
 class Chempath_Tests(unittest.TestCase):
 
     def test_get_sb(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
 
         # get first branching point
@@ -33,7 +28,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertEqual(sb, 'O3')
 
     def test_simple_ozone_find_all_pathways(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
 
         chempath.find_all_pathways()
@@ -47,7 +42,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(chempath.fk, expected_fk)))
         
     def test_get_sij(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
 
         expected_sij = np.array([[-1.,  0.,  1., -1.],
@@ -56,7 +51,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertTrue(np.all(chempath.sij == expected_sij))
 
     def test_find_pathways_one_iteration(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
 
         sb = chempath.get_sb()
@@ -82,7 +77,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(chempath.di, expected_di)))
 
     def test_is_simple_pathway(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
         xjk_test = np.array([[1., 1., 0., 0.],
                             [0., 0., 1., 1.],
@@ -94,7 +89,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertFalse(chempath.is_elementary_pathway(xjk_test, 2, 1))
 
     def test_find_elementary_pathways(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
 
         sb = chempath.get_sb()
@@ -123,7 +118,7 @@ class Chempath_Tests(unittest.TestCase):
          
         
     def test_delete_pathways(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
         chempath.f_min = 0.2
 
@@ -157,7 +152,7 @@ class Chempath_Tests(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(chempath.di_del, expected_di_del)))
 
     def test_simple_ozone_fmin_02(self):
-        path='input/simple_ozone'
+        path='input/simple_ozone.hdf5'
         chempath = get_chempath(path, ignored_sb=['O2'])
         chempath.f_min = 0.2
         chempath.find_all_pathways()

--- a/examples/box_model_pathways/box_model_pathways_example.ipynb
+++ b/examples/box_model_pathways/box_model_pathways_example.ipynb
@@ -99,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x1569e7730>"
+       "<matplotlib.legend.Legend at 0x152fbcfd0>"
       ]
      },
      "execution_count": 4,
@@ -158,6 +158,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "vscode": {
@@ -173,6 +180,26 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(7964.621056023985)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.diff(solution.time)[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -247,14 +274,9 @@
     "# create a chempath object\n",
     "i=20\n",
     "chempath = Chempath(\n",
-    "            reactions_path=f'chempath_input/reactions.txt',\n",
-    "            rates_path=f'chempath_input/rates_{i}.dat',\n",
-    "            species_path=f'chempath_input/species.txt',\n",
-    "            conc_path=f'chempath_input/num_densities_{i}.dat',\n",
-    "            time_path=f'chempath_input/time_{i}.dat',\n",
+    "            h5py_path=f'chempath_input/box_model_output_{i}.hdf5',\n",
     "            f_min=0,\n",
     "            ignored_sb=['O2', 'O3', 'H2O'],\n",
-    "            dtype=np.float64,\n",
     "            delete_error_reactions=True\n",
     "        )\n",
     "\n",
@@ -284,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,21 +321,12 @@
     "    # find pathways at each time step\n",
     "    for i in range(1,nfiles):\n",
     "        chempath = Chempath(\n",
-    "            reactions_path=f'{sol_folder}/reactions.txt',\n",
-    "            rates_path=f'{sol_folder}/rates_{i}.dat',\n",
-    "            species_path=f'{sol_folder}/species.txt',\n",
-    "            conc_path=f'{sol_folder}/num_densities_{i}.dat',\n",
-    "            time_path=f'{sol_folder}/time_{i}.dat',\n",
+    "            h5py_path=f'chempath_input/box_model_output_{i}.hdf5',\n",
     "            f_min=f_min,\n",
     "            ignored_sb=['O2', 'O3', 'H2O'],\n",
-    "            dtype=np.float64,\n",
     "            delete_error_reactions=False\n",
     "\n",
     "        )\n",
-    "\n",
-    "        # O3_idx = chempath.species_list.index('O3')\n",
-    "        # fmin = max([chempath.pi_err[O3_idx], chempath.di_err[O3_idx]])\n",
-    "        # chempath.f_min = fmin\n",
     "\n",
     "        chempath.find_all_pathways()\n",
     "        chempath.del_error_reactions()\n",
@@ -349,7 +362,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o3_prod_pathways= o3_prod_pathways.astype({'time': np.float64})\n",
+    "o3_loss_pathways= o3_loss_pathways.astype({'time': np.float64})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -584,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -607,49 +630,9 @@
     "\n",
     "# get pathways at timestep number 10\n",
     "pathways_time_10 = o3_prod_pathways[o3_prod_pathways.time\n",
-    "             == times[20]][['pathway', 'contribution']]\n",
+    "             == float(times[20])][['pathway', 'contribution']]\n",
     "# print pathways\n",
     "print(pathways_time_10.to_markdown())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['deleted_pathways']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "[x for x in o3_loss_pathways.pathway.unique() if 'del' in x]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array(['1*0,2*1', 'del', 'err'], dtype=object)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "o3_prod_pathways.pathway_id.unique() "
    ]
   },
   {

--- a/examples/box_model_pathways/photochem_box_model.py
+++ b/examples/box_model_pathways/photochem_box_model.py
@@ -3,6 +3,7 @@ import json
 import matplotlib.pyplot as plt
 from scipy.integrate import solve_ivp
 from rates import three_body_rate, weird_rates
+import h5py
 
 
 class PhotochemBoxModel():
@@ -191,47 +192,50 @@ class PhotochemBoxModel():
         
         # for each time idx
         for i, idx in enumerate(idxs):
-            
-            # save model time
-            np.array([time[idx], time[idx+1]]).\
-                tofile(f'{outpath}/time_{i}.dat') 
-              
-            # save species concentrations
-            np.array([conc[:, idx], conc[:, idx+1]]).\
-                tofile(f'{outpath}/num_densities_{i}.dat')
-            
-            dt = time[idx+1] - time[idx]
-            dn = conc[:, idx+1] - conc[:, idx]
-            dndt = dn/dt
+            h5py_filename = f"chempath_input/box_model_output_{i}.hdf5"
+            with h5py.File(h5py_filename, "w") as datafile:
+    
+                # save model time
+                model_time = np.array([time[idx], time[idx+1]])
+                datafile.create_dataset("model_time", model_time.shape, dtype='f16', 
+                    data=model_time)
+                
+                # save species concentrations
+                num_densities = np.array([conc[:, idx], conc[:, idx+1]])
+                datafile.create_dataset("num_densities", num_densities.shape, 
+                    dtype='f16', data=num_densities)
+                
+                dt = time[idx+1] - time[idx]
+                dn = conc[:, idx+1] - conc[:, idx]
+                dndt = dn/dt
 
-            # get mean reaction rate and save it
-            mean_reaction_rate = (rates[:, idx+1] + rates[:, idx])/2
-            # mean_reaction_rate.tofile(f'{outpath}/rates_{i}.dat')
-            # get reactions
-            reactions = ['+'.join(x['reactants']) + '=' +\
-                '+'.join(x['products']) for x in self.reactions_dict]
-            
-            chemprod = np.dot(self.s_ij, mean_reaction_rate)
+                # get mean reaction rate and save it
+                mean_reaction_rate = (rates[:, idx+1] + rates[:, idx])/2
+                # get reactions
+                reactions = ['+'.join(x['reactants']) + '=' +\
+                    '+'.join(x['products']) for x in self.reactions_dict]
+                
+                chemprod = np.dot(self.s_ij, mean_reaction_rate)
 
-            # error rate
-            error_rates = dndt - chemprod
-            err_reactions = [f'{sp}_err = {sp}' for 
-                sp in self.species_list]
-            
-            # concatenate all reaction and rates
-            all_reactions = np.concatenate([reactions, err_reactions])
-            all_rates = np.concatenate([mean_reaction_rate, error_rates])
-            
-            # save rates
-            all_rates.tofile(f'{outpath}/rates_{i}.dat')
+                # error rate
+                error_rates = dndt - chemprod
+                err_reactions = [f'{sp}_err={sp}' for 
+                    sp in self.species_list]
+                
+                # concatenate all reaction and rates
+                all_reactions = reactions + err_reactions
+                all_rates = np.concatenate([mean_reaction_rate, error_rates])
+                
+                # save rates
+                datafile.create_dataset("rates", all_rates.shape, 
+                    dtype='f16', data=all_rates)
 
-            # save reaction equations and species names
-            if i == 0:
-                np.savetxt(f'{outpath}/reactions.txt', all_reactions,
-                    fmt="%s", delimiter=',')
-                np.savetxt(f'{outpath}/species.txt', self.species_list,
-                    fmt="%s", delimiter=',')      
-
+                # save reaction equations and species names
+                datafile.create_dataset("reaction_equations", len(all_reactions), 
+                    dtype=h5py.string_dtype(), data=all_reactions)
+                datafile.create_dataset("species_names", (len(self.species_list)), 
+                    dtype=h5py.string_dtype(), data=self.species_list)
+   
     def print_reactions(self):
         for reaction in self.reactions_dict:
             print(' + '.join(reaction['reactants']) + ' --> ' +\

--- a/examples/photochem_modern_earth/get_pathways.py
+++ b/examples/photochem_modern_earth/get_pathways.py
@@ -1,9 +1,11 @@
-from chempath import Chempath
+from chempath6 import Chempath
 import pandas as pd
 import pathlib
 from multiprocessing import Pool
 from functools import partial
 import numpy as np
+import os
+import glob
 
 
 OUTPUT_FOLDER = 'pathways'
@@ -24,12 +26,9 @@ def get_pathways_contributions(alt_idx, time_idx):
     '''Gets pathways contributions at an specific altitude and time index'''
     # get a chempath object
     chempath = Chempath(
-        reactions_path=f'{INPUT_PATH}/{alt_idx}/reactions.txt',
-        rates_path=f'{INPUT_PATH}/{alt_idx}/rates_{time_idx}.dat',
-        species_path=f'{INPUT_PATH}/{alt_idx}/species.txt',
-        conc_path=f'{INPUT_PATH}/{alt_idx}/num_densities_{time_idx}.dat',
-        time_path=f'{INPUT_PATH}/{alt_idx}/time_{time_idx}.dat',
-        transport_species = True
+        h5py_path=f'{INPUT_PATH}/{alt_idx}/photochem_output_{time_idx}.hdf5',
+        transport_species = True,
+        delete_error_reactions = False
     )
 
     # ignore these species as branching-points
@@ -40,8 +39,11 @@ def get_pathways_contributions(alt_idx, time_idx):
     f_min = get_fmin(chempath)
     chempath.f_min = f_min
 
-    # find all pathways
-    chempath.find_all_pathways()
+    e = chempath.find_all_pathways(timeout=60*60*2) 
+            #method='lehmann')
+    chempath.del_error_reactions()
+    if e == 'timed out':
+        return None, None
 
     # get contributions
     alt = np.arange(0.5,100, 1)
@@ -96,5 +98,17 @@ def get_all_contrib_dfs(time_idx):
         compression='gzip')
 
 
-time_idx = 169
-get_all_contrib_dfs(time_idx)
+cwd = os.getcwd()
+folder = 'pathways'
+
+def get_idxs(name):
+    i1 = name.rfind('_') + 1
+    i2 = name.rfind('.') 
+    return int(name[i1:i2])
+
+files = glob.glob(folder+'/0/photochem_output*')
+time_idxs = [get_idxs(x) for x in files]
+time_idxs = np.sort(time_idxs)[::-1]
+
+for i in time_idxs:
+    get_all_contrib_dfs(i)

--- a/examples/photochem_modern_earth/photochem_output_to_chempath.py
+++ b/examples/photochem_modern_earth/photochem_output_to_chempath.py
@@ -1,7 +1,7 @@
 import numpy as np
-from photochem import EvoAtmosphere, zahnle_earth
 import pathlib
 from multiprocessing import Pool
+import h5py
     
 INPUT_PATH = 'photochem_output'
 OUTPUT_PATH = 'chempath_input'
@@ -23,6 +23,8 @@ distributed_fluxes = np.fromfile(f'{INPUT_PATH}/distributed_fluxes.dat',
 times = np.fromfile(f'{INPUT_PATH}/time.dat', dtype=np.float128)
 ispec = np.loadtxt(f'{INPUT_PATH}/species.txt', dtype=str, delimiter=',')
 reactions = np.loadtxt(f'{INPUT_PATH}/reactions.txt', dtype=str, delimiter=',')
+reactions = [str(x) for x in reactions]
+ispec = [str(x) for x in ispec]
 
 def get_sij(species_names, reaction_equations):
     '''Gets number of molecules/cm^3 or ppb of species i produced by reaction j in
@@ -78,7 +80,7 @@ def photochem_to_cehmpath(output_path, layer=None):
     to15_i = int(to15.shape[0]/15)
     idxs2 = np.concatenate([to13[::to13_i], to15[::to15_i]])
     time_idxs = np.concatenate([idxs1, idxs2, [times.shape[0]-1]])
-
+    time_idxs = time_idxs[:-1]
     # for each altitude
     for j, alt in enumerate(alts):
         if layer or layer != 0:
@@ -94,73 +96,80 @@ def photochem_to_cehmpath(output_path, layer=None):
         # for each time
         for i in time_idxs:
             print(i)
+            h5py.string_dtype(encoding='utf-8', length=None)
             pathlib.Path(f'{output_path}/{j}/').mkdir(exist_ok=True, parents=True)
-            
-            # get dt
-            dt = times[i+1] - times[i]
+            h5py_filename = f"{output_path}/{j}/photochem_output_{i}.hdf5"
+            with h5py.File(h5py_filename, "w") as datafile:
+                # get dt
+                dt = times[i+1] - times[i]
+                model_time = np.array([times[i], times[i+1]])
 
-            # get conc change
-            num_den_change = num_densities_alt[i+1] - num_densities_alt[i]
+                # number densities
+                nd = np.array([num_densities_alt[i], num_densities_alt[i+1]])
 
-            # get mean reaction rates
-            mean_reaction_rate = (reaction_rates_alt[i+1] + reaction_rates_alt[i])/2
+                # get conc change
+                num_den_change = num_densities_alt[i+1] - num_densities_alt[i]
 
-            # get rainout rates
-            rainout_reactions = [f'{x} = {x}_rainout' for x in ispec]
-            mean_rainout_rate = (rainout_rates_alt[i+1] + rainout_rates_alt[i])/2
-            # append zeros so rainout has the same shape as rates
-            mean_rainout_rate = np.concatenate([mean_rainout_rate, np.zeros(2)])
+                # get mean reaction rates
+                mean_reaction_rate = (reaction_rates_alt[i+1] + reaction_rates_alt[i])/2
 
-            # get transport rates
-            transport_reactions = [f'{sp}_transport = {sp}' for sp in ispec]
-            mean_transport_rate = (transport_rates_alt[i+1] + transport_rates_alt[i])/2
-            # append zeros so transport has the same shape as rates
-            mean_transport_rate = np.concatenate([mean_transport_rate, np.zeros(2)])
+                # get rainout rates
+                rainout_reactions = [f'{x} = {x}_rainout' for x in ispec]
+                mean_rainout_rate = (rainout_rates_alt[i+1] + rainout_rates_alt[i])/2
+                # append zeros so rainout has the same shape as rates
+                mean_rainout_rate = np.concatenate([mean_rainout_rate, np.zeros(2)])
 
-            # get distributed fluxes
-            dist_flux_reactions = [f'{sp}_distflx = {sp}' for sp in ispec]
-            mean_dist_flux= (dist_flux_alt[i+1] + dist_flux_alt[i])/2
-            # append zeros so transport has the same shape as rates
-            mean_dist_flux= np.concatenate([mean_dist_flux, np.zeros(2)])
+                # get transport rates
+                transport_reactions = [f'{sp}_transport = {sp}' for sp in ispec]
+                mean_transport_rate = (transport_rates_alt[i+1] + transport_rates_alt[i])/2
+                # append zeros so transport has the same shape as rates
+                mean_transport_rate = np.concatenate([mean_transport_rate, np.zeros(2)])
 
-            # calculate error rates
-            dn_dt = num_den_change/dt
-            chemprod = np.dot(sij, mean_reaction_rate)
-            # chemprod[73:] = 0 # photochemical steady state for SL species
-            # assuming that dn = (P-L)dt + Rdt + Phi*dt
-            total_prod = chemprod + mean_transport_rate -\
-                mean_rainout_rate + mean_dist_flux
-            error_rates = (dn_dt -total_prod)
-            # get error reactions
-            err_reactions = [f'{sp}_err = {sp}' for sp in ispec]
+                # get distributed fluxes
+                dist_flux_reactions = [f'{sp}_distflx = {sp}' for sp in ispec]
+                mean_dist_flux= (dist_flux_alt[i+1] + dist_flux_alt[i])/2
+                # append zeros so transport has the same shape as rates
+                mean_dist_flux= np.concatenate([mean_dist_flux, np.zeros(2)])
 
-            # concatenate all reaction and rates
-            all_reactions = np.concatenate([reactions, rainout_reactions,
-                transport_reactions, dist_flux_reactions, err_reactions])
-            all_rates = np.concatenate([mean_reaction_rate, 
-                mean_rainout_rate, mean_transport_rate, mean_dist_flux,
-                error_rates])
-            
-            # save rates
-            all_rates.tofile(f'{output_path}/{j}/rates_{i}.dat')
-            # save model time
-            np.array([times[i], times[i+1]]).\
-                tofile(f'{output_path}/{j}/time_{i}.dat')
-            # save number densities
-            np.array([num_densities_alt[i], num_densities_alt[i+1]]).\
-                tofile(f'{output_path}/{j}/num_densities_{i}.dat')
-            
-            # save reaction system and species names
-            if i == 0:
-                np.savetxt(f'{output_path}/{j}/reactions.txt', all_reactions,
-                    fmt="%s", delimiter=',')
-                np.savetxt(f'{output_path}/{j}/species.txt', ispec,
-                    fmt="%s", delimiter=',')
+                # calculate error rates
+                dn_dt = num_den_change/dt
+                chemprod = np.dot(sij, mean_reaction_rate)
+                # chemprod[73:] = 0 # photochemical steady state for SL species
+                # assuming that dn = (P-L)dt + Rdt + Phi*dt
+                total_prod = chemprod + mean_transport_rate -\
+                    mean_rainout_rate + mean_dist_flux
+                error_rates = (dn_dt -total_prod)
+                # get error reactions
+                err_reactions = [f'{sp}_err = {sp}' for sp in ispec]
+
+                # concatenate all reaction and rates
+                all_reactions = reactions + rainout_reactions +\
+                    transport_reactions + dist_flux_reactions + err_reactions
+                all_rates = np.concatenate([mean_reaction_rate, 
+                    mean_rainout_rate, mean_transport_rate, mean_dist_flux,
+                    error_rates])
                 
+                # save rates
+                datafile.create_dataset("rates", all_rates.shape, 
+                    dtype='f16', data=all_rates)
+                # save model time
+                datafile.create_dataset("model_time", model_time.shape, dtype='f16', 
+                    data=model_time)
+                # save number densities
+                datafile.create_dataset("num_densities", nd.shape, 
+                    dtype='f16', data=nd)
+                # save reaction equations and species names
+                datafile.create_dataset("reaction_equations", [len(all_reactions)], 
+                    dtype=h5py.string_dtype(), data=all_reactions)
+                datafile.create_dataset("species_names", [len(ispec)], 
+                    dtype=h5py.string_dtype(), data=ispec)
+                    
 
 # run each altutude in a different process
 layers = np.arange(0,100, dtype=int)
 def photochem2PAP_wrapper(layer):
     photochem_to_cehmpath(OUTPUT_PATH, layer=layer)
-with Pool(processes=30) as pool:
-    pool.map(photochem2PAP_wrapper, layers)
+
+for layer in layers:
+    photochem2PAP_wrapper(layer)
+

--- a/examples/photochem_modern_earth/run_photochem_model.py
+++ b/examples/photochem_modern_earth/run_photochem_model.py
@@ -155,6 +155,39 @@ def save_number_densities(path):
     # save data to csv file
     data.to_csv(f'{OUTPUT_FOLDER}/number_densities.csv', compression='gzip')
 
+def save_mixing_ratios(path):
+    # species to save data for
+    species = ['O2', 'O3', 'CH4', 'CO', 'H2', 'OH', 'HO2', 'O', 'NO','NO2', 
+        'CH3O2']
+    # read species file
+    ispec = np.loadtxt(f'{path}/species.txt', dtype=str, delimiter=',')
+
+    # read number densities
+    num_den_shape = np.loadtxt(f'{path}/num_densities.shape').astype(int)
+    num_den_shape[1] = num_den_shape[1] +1
+    mixing_ratios = np.fromfile(f'{path}/mixing_ratios.dat',
+        dtype=np.float64).reshape(num_den_shape)
+
+    # read time
+    times = np.fromfile(f'{path}/time.dat', dtype=np.float128)
+    alts = np.arange(0.5, 100, 1)
+
+    # get species indexes
+    sp_idx = np.array([np.where(ispec == sp)[0][0] for sp in species])
+
+    # create a dataframe with number densities
+    data = []
+    for i in range(0, len(times)):
+        data_sp = pd.DataFrame(mixing_ratios[i, sp_idx, :].T.astype(float),
+            columns=species)
+        data_sp['time'] = times[i]
+        data_sp['alt'] = alts
+        data.append(data_sp)
+    data = pd.concat(data)
+
+    # save data to csv file
+    data.to_csv(f'{OUTPUT_FOLDER}/mixing_ratios.csv', compression='gzip')
+
 # run model for 5 my
 yrs=60*60*24*365
 run_model(OUTPUT_FOLDER, tf=5*yrs*1e6, t_save=0.1*yrs*1e6)

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -11,61 +11,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from chempath import Chempath, get_latex_contribution_table\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import h5py"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Chempath requires four inputs from a chemical kinetics model in at two consecutive time steps: the reaction system with $n_r$ reactions between $n_s$ species, the species concentrations, the reaction rates, and the model time. The user can also input a minimum rate of pathways $f_{min}$. These input files need to be in a specific format. The folder `input` includes some examples of Chempath input files. The units can be any type of concentration, time and rate units as long as they are consistent. Lets explore these files:"
+    "Chempath requires four inputs from a chemical kinetics model in at two consecutive time steps: the reaction system with $n_r$ reactions between $n_s$ species, the species concentrations, the reaction rates, and the model time. The user can also input a minimum rate of pathways $f_{min}$. Chempath uses hdf5 binary files as input. The folder `input` includes some examples of Chempath input files. The units can be any type of concentration, time and rate units as long as they are consistent. Lets explore the contents of one of these files:"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Chempath needs:\n",
+    "The input file includes:\n",
     "\n",
-    "- a reaction file with a list of reactions:"
+    "- a list of reactions:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reactions:  ['H2O2+OH=HO2+H2O' 'OH+OH=H2O2' 'H2O2+O=OH+HO2' 'HO2+HV=OH+O'\n",
-      " 'HO2+O=OH+O2']\n"
+      "Reactions:  [b'H2O2+OH=HO2+H2O' b'OH+OH=H2O2' b'H2O2+O=OH+HO2' b'HO2+HV=OH+O'\n",
+      " b'HO2+O=OH+O2']\n"
      ]
     }
    ],
    "source": [
-    "input_folder = 'input/simple_HOx/'\n",
-    "# read reactions file\n",
-    "reactions = np.loadtxt(f'{input_folder}/reactions.txt', dtype=str)\n",
-    "print('Reactions: ', reactions)\n"
+    "h5py_filename = 'input/simple_HOx.hdf5'\n",
+    "with h5py.File(h5py_filename, \"r\") as datafile:\n",
+    "    reactions = datafile['reaction_equations'][:]\n",
+    "    print('Reactions: ', reactions)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- a rates file with a rate for each reaction:"
+    "- an array of reaction rates with a rate for each reaction:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -77,47 +78,47 @@
     }
    ],
    "source": [
-    "# read rates file\n",
-    "rates = np.fromfile(f'{input_folder}/rates.dat', dtype=np.float64)\n",
-    "print('Rates (ppb/hr): ',rates)"
+    "with h5py.File(h5py_filename, \"r\") as datafile:\n",
+    "    rates = datafile['rates'][:]\n",
+    "    print('Rates (ppb/hr): ',rates)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- a species file with the species names:"
+    "- an array with the species names:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Species:  ['H2O2' 'OH' 'HO2' 'H2O' 'O' 'O2']\n"
+      "Species:  [b'H2O2' b'OH' b'HO2' b'H2O' b'O' b'O2']\n"
      ]
     }
    ],
    "source": [
-    "# read species file\n",
-    "species = np.loadtxt(f'{input_folder}/species.txt', dtype=str)\n",
-    "print('Species: ',species)\n"
+    "with h5py.File(h5py_filename, \"r\") as datafile:\n",
+    "    species = datafile['species_names'][:]\n",
+    "    print('Species: ',species)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- a model time file with two consecutive model times"
+    "- an array with two consecutive model times"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -129,21 +130,21 @@
     }
    ],
    "source": [
-    "# read model time file\n",
-    "model_time = np.fromfile(f'{input_folder}/model_time.dat', dtype=np.float64)\n",
-    "print('Model time (hr): ',model_time)"
+    "with h5py.File(h5py_filename, \"r\") as datafile:\n",
+    "    model_time = datafile['model_time'][:]\n",
+    "    print('Model time (hr): ',model_time)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- a concentrations file with the concentrations of the species at each model time:"
+    "- an array with the concentrations of the species at each model time:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -156,9 +157,9 @@
     }
    ],
    "source": [
-    "# read species concentrations file\n",
-    "concentrations = np.fromfile(f'{input_folder}/concentrations.dat', dtype=np.float64)\n",
-    "print('Concentrations (ppb): ',concentrations.reshape(2, len(species)))"
+    "with h5py.File(h5py_filename, \"r\") as datafile:\n",
+    "    concentrations = datafile['num_densities'][:]\n",
+    "    print('Concentrations (ppb): ',concentrations)"
    ]
   },
   {
@@ -170,19 +171,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_folder = 'input/simple_ozone/'\n",
     "chempath = Chempath(\n",
-    "        reactions_path=f'{input_folder}/reactions.txt', # file with reaction equations\n",
-    "        rates_path=f'{input_folder}/rates.dat', # file with reaction rates\n",
-    "        species_path=f'{input_folder}/species.txt', # file with species names\n",
-    "        conc_path=f'{input_folder}/concentrations.dat', # file concentrations of species\n",
-    "        time_path=f'{input_folder}/model_time.dat', # file with model time\n",
+    "        h5py_path= 'input/simple_ozone.hdf5',\n",
     "        f_min=0, # minimum rate of pathways\n",
-    "        dtype=np.float64, # data type of rates and concentrations,\n",
     "        ignored_sb = ['O2'] # ignore O2 as a branching-point species\n",
     "    )"
    ]
@@ -230,14 +225,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reactions:  ['O3+hv=O+O2' 'O2+hv=O+O' 'O+O2+M=O3' 'O+O3=O2+O2']\n",
+      "Reactions:  [np.str_('O3+hv=O+O2'), np.str_('O2+hv=O+O'), np.str_('O+O2+M=O3'), np.str_('O+O3=O2+O2')]\n",
       "Rates:  [80. 10. 99.  1.]\n"
      ]
     }
@@ -256,14 +251,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Species:  [np.str_('O3'), np.str_('O2'), np.str_('O')]\n",
+      "Species:  ['O3', 'O2', 'O']\n",
       "Mean concentrations  [1.00009000e+05 9.99999865e+07 1.00000000e+02]\n",
       "Concentration changes:  [ 18. -27.   0.]\n"
      ]
@@ -284,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -355,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -397,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +403,7 @@
       "\u001b[0;31mDocstring:\u001b[0m\n",
       "Gets the indexes of the pathways producing and destroying Sb\n",
       "        \n",
-      "\u001b[0;31mFile:\u001b[0m      ~/Files/projects/Pathway Analysis/chempath/chempath.py\n",
+      "\u001b[0;31mFile:\u001b[0m      ~/tests/chempath/chempath.py\n",
       "\u001b[0;31mType:\u001b[0m      method"
      ]
     }
@@ -426,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +431,7 @@
        "\twith 8 stored elements in Compressed Sparse Column format>"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -472,7 +467,7 @@
       "        the pathway string\n",
       "Returns:\n",
       "    pathway string (str)\n",
-      "\u001b[0;31mFile:\u001b[0m      ~/Files/projects/Pathway Analysis/chempath/chempath.py\n",
+      "\u001b[0;31mFile:\u001b[0m      ~/tests/chempath/chempath.py\n",
       "\u001b[0;31mType:\u001b[0m      method"
      ]
     }
@@ -490,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -542,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -567,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -585,7 +580,7 @@
       "    'latex'\n",
       "Returns:\n",
       "    contrib_df: pandas dataframe with contributions    \n",
-      "\u001b[0;31mFile:\u001b[0m      ~/Files/projects/Pathway Analysis/chempath/chempath.py\n",
+      "\u001b[0;31mFile:\u001b[0m      ~/tests/chempath/chempath.py\n",
       "\u001b[0;31mType:\u001b[0m      method"
      ]
     }
@@ -596,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -656,6 +651,15 @@
        "      <td>0.0</td>\n",
        "      <td>18.0</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>err</td>\n",
+       "      <td>err_pathways</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>18.0</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -665,14 +669,16 @@
        "0    1*0,1*3    O3+hv -> O+O2\\nO+O3 -> O2+O2\\nNet:2O3 -> 3O2      0.888889   \n",
        "1    1*1,2*3  O2+hv -> O+O\\n2(O+O3 -> O2+O2)\\nNet:2O3 -> 3O2      0.111111   \n",
        "2        del                                deleted_pathways      0.000000   \n",
+       "3        err                                    err_pathways      0.000000   \n",
        "\n",
        "   rate  total_prod  dconc  \n",
        "0   0.8        -1.6   18.0  \n",
        "1   0.1        -0.2   18.0  \n",
-       "2   0.0         0.0   18.0  "
+       "2   0.0         0.0   18.0  \n",
+       "3   0.0         0.0   18.0  "
       ]
      },
-     "execution_count": 53,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -683,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -743,6 +749,15 @@
        "      <td>0.0</td>\n",
        "      <td>-27.0</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>err</td>\n",
+       "      <td>err_pathways</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>-27.0</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -752,14 +767,16 @@
        "0    1*0,1*3    O3+hv -> O+O2\\nO+O3 -> O2+O2\\nNet:2O3 -> 3O2      0.888889   \n",
        "1    1*1,2*3  O2+hv -> O+O\\n2(O+O3 -> O2+O2)\\nNet:2O3 -> 3O2      0.111111   \n",
        "2        del                                deleted_pathways      0.000000   \n",
+       "3        err                                    err_pathways      0.000000   \n",
        "\n",
        "   rate  total_prod  dconc  \n",
        "0   0.8         2.4  -27.0  \n",
        "1   0.1         0.3  -27.0  \n",
-       "2   0.0         0.0  -27.0  "
+       "2   0.0         0.0  -27.0  \n",
+       "3   0.0         0.0  -27.0  "
       ]
      },
-     "execution_count": 54,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -777,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -829,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -882,16 +899,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[np.str_('O'), np.str_('O3')]"
+       "['O', 'O3']"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -911,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -962,7 +979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -988,7 +1005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1015,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1056,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1134,6 +1151,15 @@
        "      <td>0.000000</td>\n",
        "      <td>1.2</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>err</td>\n",
+       "      <td>err_pathways</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.2</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -1145,32 +1171,28 @@
        "2        1*4             HO2+O -> OH+O2\\nNet:HO2 + O -> OH + O2      0.183333   \n",
        "3    1*3,1*4  HO2+HV -> OH+O\\nHO2+O -> OH+O2\\nNet:2HO2 -> 2O...      0.122222   \n",
        "4        del                                   deleted_pathways      0.000000   \n",
+       "5        err                                       err_pathways      0.000000   \n",
        "\n",
        "       rate  total_prod  dconc  \n",
        "0  0.272727    0.545455    1.2  \n",
        "1  0.181818    0.363636    1.2  \n",
        "2  0.240000    0.240000    1.2  \n",
        "3  0.080000    0.160000    1.2  \n",
-       "4  0.000000    0.000000    1.2  "
+       "4  0.000000    0.000000    1.2  \n",
+       "5  0.000000    0.000000    1.2  "
       ]
      },
-     "execution_count": 62,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# initialize chempath\n",
-    "input_folder = 'input/simple_HOx/'\n",
     "chempath = Chempath(\n",
-    "        reactions_path=f'{input_folder}/reactions.txt', # file with reaction equations\n",
-    "        rates_path=f'{input_folder}/rates.dat', # file with reaction rates\n",
-    "        species_path=f'{input_folder}/species.txt', # file with species names\n",
-    "        conc_path=f'{input_folder}/concentrations.dat', # file concentrations of species\n",
-    "        time_path=f'{input_folder}/model_time.dat', # file with model time\n",
+    "        h5py_path= 'input/simple_HOx.hdf5',\n",
     "        f_min=0.05, # minimum rate of pathways\n",
-    "        dtype=np.float64, # data type of rates and concentrations,\n",
-    "        ignored_sb = ['O2', 'H2O', 'OH'] # ignore HO2 and H2O as a branching-point species\n",
+    "        ignored_sb = ['O2'] # ignore O2 as a branching-point species\n",
     "    )\n",
     "\n",
     "# finad all pathways\n",
@@ -1182,7 +1204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1224,16 +1246,26 @@
        "      <td>0.109091</td>\n",
        "      <td>1.2</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>err</td>\n",
+       "      <td>err_pathways</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.2</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "  pathway_id           pathway  contribution      rate  total_prod  dconc\n",
-       "0        del  deleted_pathways           1.0  0.109091    0.109091    1.2"
+       "0        del  deleted_pathways           1.0  0.109091    0.109091    1.2\n",
+       "1        err      err_pathways           0.0  0.000000    0.000000    1.2"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1244,14 +1276,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pathway 1 with rate=0.24ppb:\n",
+      "Pathway 1 with rate=0.23999999999999994ppb:\n",
       "HO2+O -> OH+O2\n",
       "Net:HO2 + O -> OH + O2\n",
       "\n",
@@ -1262,7 +1294,7 @@
       "Net:H2O2 -> 2OH\n",
       "\n",
       "\n",
-      "Pathway 3 with rate=0.08ppb:\n",
+      "Pathway 3 with rate=0.07999999999999999ppb:\n",
       "HO2+HV -> OH+O\n",
       "HO2+O -> OH+O2\n",
       "Net:2HO2 -> 2OH + O2\n",
@@ -1308,7 +1340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1344,13 +1376,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1359,7 +1384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1375,6 +1400,7 @@
       "2 & 1*4 & \\ce{ HO2 + O -> OH + O2\\\\\\text{Net:} HO2 + O -> OH + O2 } & 0.183333 & 0.240000 & 0.240000 & 1.200000 \\\\\n",
       "3 & 1*3,1*4 & \\ce{ HO2 + HV -> OH + O\\\\HO2 + O -> OH + O2\\\\\\text{Net:} 2HO2 -> 2OH + O2 } & 0.122222 & 0.080000 & 0.160000 & 1.200000 \\\\\n",
       "4 & del & deleted_pathways & 0.000000 & 0.000000 & 0.000000 & 1.200000 \\\\\n",
+      "5 & err & err_pathways & 0.000000 & 0.000000 & 0.000000 & 1.200000 \\\\\n",
       "\\bottomrule\n",
       "\\end{tabular}\n",
       "\n"
@@ -1387,7 +1413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1407,7 +1433,8 @@
       "|  3 | HO2+HV -> OH+O            |       0.122222 | 0.08     |\n",
       "|    | HO2+O -> OH+O2            |                |          |\n",
       "|    | Net:2HO2 -> 2OH + O2      |                |          |\n",
-      "|  4 | deleted_pathways          |       0        | 0        |\n"
+      "|  4 | deleted_pathways          |       0        | 0        |\n",
+      "|  5 | err_pathways              |       0        | 0        |\n"
      ]
     }
    ],
@@ -1415,6 +1442,27 @@
     "contribution_df = chempath.get_pathways_contributions('OH', on='production',\n",
     "    format='txt')\n",
     "print(contribution_df[['pathway', 'contribution', 'rate']].to_markdown())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.24      , 0.18181818, 0.08      , 0.27272727, 0.21818182,\n",
+       "       0.32727273], dtype=float128)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chempath.fk"
    ]
   }
  ],


### PR DESCRIPTION
Convert the Chempath input files from NumPy binary format to HDF5 format using h5py.

Using h5py input fields simplifies the syntax for reading files.